### PR TITLE
removed pytest logging?

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ jsonpickle>=0.0
 behave>=0.0
 jsonpath_rw>=0.0
 pytest>=0.0
-pytest_logging>=0.0
 percache>=0.0
 pydotplus>=0.0
 cachier>=0.1.26


### PR DESCRIPTION
Doesn't look like pytest-logging is supported by 3.6.  Should we use 3.5 only, or are we safe to remove it? 

https://pypi.python.org/pypi/pytest-logging

Seems to work fine without it (do the behave tests rely on it?)

Otherwise with 3.6 we get an error.    In that same vein, can we remove pytest as a requirement as well? 

