### PR TITLE
Check for facet_counts before creating closure bins

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -442,7 +442,7 @@ class DiseasePhenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
         fcs = results.get('facet_counts')
-        if fcs is not None:
+        if fcs:
             fcs['closure_bin'] = create_closure_bin(fcs.get('object_closure'))
         return results
 


### PR DESCRIPTION
Fixes a bug reported by @DoctorBud 

> There appears to be a bug with use_compact_associations=true and the /bioentity/disease/ID/phenotypes endpoint. For example, this works fine:
https://api-dev.monarchinitiative.org/api/bioentity/disease/MONDO%3A0007947/phenotypes?rows=100&fetch_objects=false&use_compact_associations=false
> 
> but this will return Internal Server Error:
https://api-dev.monarchinitiative.org/api/bioentity/disease/MONDO%3A0007947/phenotypes?rows=100&fetch_objects=false&use_compact_associations=true
> 
> The other /bioentity/disease/ID/* endpoints work fine with use_compact_associations=true. I think it's just a plain-ole-bug somewhere.

**Note to self:** Check the need for closure_bin and implement in other API calls as needed

