### PR TITLE
Fixed typo in Scigraph API call

### DIFF
--- a/biolink/api/nlp/endpoints/annotate.py
+++ b/biolink/api/nlp/endpoints/annotate.py
@@ -43,9 +43,6 @@ def parse_args_for_annotator(parser):
     if 'include_acronym' in args:
         val = args.pop('include_acronym')
         args['includeAcronym'] = val
-    if 'include_acronym' in args:
-        val = args.pop('include_acronym')
-        args['includeAcronym'] = val
     if 'include_numbers' in args:
         val = args.pop('include_numbers')
         args['includeNumbers'] = val

--- a/biolink/api/nlp/endpoints/annotate.py
+++ b/biolink/api/nlp/endpoints/annotate.py
@@ -39,7 +39,7 @@ def parse_args_for_annotator(parser):
         args['longestOnly'] = val
     if 'include_abbreviation' in args:
         val = args.pop('include_abbreviation')
-        args['include_abbrev'] = val
+        args['includeAbbrev'] = val
     if 'include_acronym' in args:
         val = args.pop('include_acronym')
         args['includeAcronym'] = val


### PR DESCRIPTION
Typo consisted of renaming `include_abbrev` to `includeAbbrev`, as per https://scigraph-ontology.monarchinitiative.org/scigraph/docs/

Also removed some duplicated code.